### PR TITLE
fix(running_jobs): immediately consume the message when possible

### DIFF
--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -173,13 +173,12 @@ func (handler *SQSHandler) HandleSQSMessage(m *mq.Message) error {
 		}
 	}
 
-	for len(jobMap)+GetNumberRunningJobs(jobNameList) > GetMaxJobConfig() {
-		time.Sleep(5 * time.Second)
-	}
-
 	glog.Infof("Start to run %d jobs", len(jobMap))
 
 	for objectPath, jobConfig := range jobMap {
+		for GetNumberRunningJobs(jobNameList) > GetMaxJobConfig() {
+			time.Sleep(5 * time.Second)
+		}
 		glog.Info("Processing: ", objectPath)
 		result, err := CreateK8sJob(objectPath, jobConfig)
 		if err != nil {


### PR DESCRIPTION
A SQS message can contains N object paths. Currently SSJDIspatcher will sleep until there is enough resource to support N jobs. This patch to allow the service consumes the message a.s.a.p