### PR TITLE
fix(docker): bump golang to 1.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10 as build-deps
+FROM golang:1.12 as build-deps
 
 # Temporary, until kubernetes/client-go#656 gets resolved.
 RUN go get k8s.io/klog && cd $GOPATH/src/k8s.io/klog && git checkout v0.4.0

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -486,6 +486,7 @@
     "github.com/stretchr/testify/assert",
     "k8s.io/api/batch/v1",
     "k8s.io/api/core/v1",
+    "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/typed/batch/v1",


### PR DESCRIPTION
### Breaking Changes
bump `go` version to 1.12
