### PR TITLE
chore(qa): Removing klog dep installation as it is not used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM golang:1.12 as build-deps
 
-# Temporary, until kubernetes/client-go#656 gets resolved.
-RUN go get k8s.io/klog && cd $GOPATH/src/k8s.io/klog && git checkout v0.4.0
-
 RUN go get -tags k8s.io/client-go/kubernetes \
     k8s.io/apimachinery/pkg/apis/meta/v1 \
     k8s.io/api/core/v1 \


### PR DESCRIPTION
This module is no longer being used.