### PR TITLE
Address SQS issue with data duplication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/uc-cdis/ssjdispatcher
 
-go 1.13
+go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.33.11

--- a/go.sum
+++ b/go.sum
@@ -48,7 +48,6 @@ github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
@@ -73,7 +72,6 @@ github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OI
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
-github.com/googleapis/gnostic v0.1.0 h1:rVsPeBmXbYv4If/cumu1AzZPwV58q433hvONV1UEZoI=
 github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.4.0 h1:BXDUo8p/DaxC+4FJY/SSx3gvnx9C1VdHNgaUkiEL5mk=
 github.com/googleapis/gnostic v0.4.0/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
@@ -88,7 +86,6 @@ github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeY
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
-github.com/json-iterator/go v1.1.8 h1:QiWkFLKq0T7mpzwOTu6BzNDbfTE8OLrYhVKYMLF46Ok=
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -118,7 +115,6 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -130,17 +126,15 @@ github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzu
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/uc-cdis/ssjdispatcher v0.0.0-20200720211707-b645c7e99640 h1:MmJ6UhHxkNTV+Z56LF3u7kwBvpmBt2uTounSdyCzaII=
-github.com/uc-cdis/ssjdispatcher v0.0.0-20200720211707-b645c7e99640/go.mod h1:fvJBE/VRQmgodCXhJsJ/WnB5dSUj6ioj7gjDFpXsuhw=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8 h1:1wopBVtVdWnn03fZelqdXTqk7U7zPQCb+T4rbU9ZEoU=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -158,7 +152,6 @@ golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
@@ -186,7 +179,6 @@ golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/handlers/awsclient.go
+++ b/handlers/awsclient.go
@@ -30,7 +30,6 @@ func NewSQSClient() (sqsiface.SQSAPI, error) {
 		sess, _ := session.NewSession()
 		return sqs.New(sess), nil
 	}
-
 }
 
 // loadCredentialFromConfigFile loads AWS credentials from the config file

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -128,11 +128,10 @@ func (handler *SQSHandler) RemoveSQSMessage(message *sqs.Message) error {
 func (handler *SQSHandler) StartMonitoringProcess() {
 	for {
 		jobs := handler.jobHandler.listJobs().JobInfo
-		glog.Warningf("[StartMonitoringProcess] found %d jobs", len(jobs))
+		glog.Infof("[StartMonitoringProcess] found %d jobs", len(jobs))
 
 		for _, jobInfo := range jobs {
-			glog.Warningf("[StartMonitoringProcess] checking: %q - status: %q [%s]", jobInfo.Name, jobInfo.Status, jobInfo.UID)
-			glog.Warningf("[StartMonitoringProcess] checking: %q - details\n\t%s", jobInfo.DetailedStatus())
+			glog.Infof("[StartMonitoringProcess] checking: %q - status: %q [%s]", jobInfo.Name, jobInfo.Status, jobInfo.DetailedStatus())
 		}
 
 		time.Sleep(30 * time.Second)

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -70,7 +70,7 @@ func (handler *SQSHandler) StartServer() error {
 	return nil
 }
 
-// StartConsumingProcess starts consumming the queue
+// StartConsumingProcess starts consuming the queue
 func (handler *SQSHandler) StartConsumingProcess() error {
 	receiveParams := &sqs.ReceiveMessageInput{
 		QueueUrl:            aws.String(handler.QueueURL),

--- a/handlers/handler_api.go
+++ b/handlers/handler_api.go
@@ -63,7 +63,7 @@ func (handler *SQSHandler) deleteJobConfig(w http.ResponseWriter, r *http.Reques
 		http.Error(w, msg, http.StatusBadRequest)
 		return
 	}
-	fmt.Fprintf(w, "Successfully delete the job")
+	w.Write([]byte("Successfully delete the job"))
 }
 
 func (handler *SQSHandler) listJobConfigs(w http.ResponseWriter, r *http.Request) {
@@ -72,7 +72,7 @@ func (handler *SQSHandler) listJobConfigs(w http.ResponseWriter, r *http.Request
 		msg := fmt.Sprintf("failed to list job config; encountered error: %s", err)
 		http.Error(w, msg, http.StatusInternalServerError)
 	}
-	fmt.Fprintf(w, str)
+	w.Write([]byte(str))
 }
 
 // HandleDispatchJob dispatch an job
@@ -116,7 +116,7 @@ func (handler *SQSHandler) getIndexingJobStatus(w http.ResponseWriter, r *http.R
 	url := r.URL.Query().Get("url")
 	if url != "" {
 		status := handler.getJobStatusByCheckingMonitoredJobs(url)
-		fmt.Fprintf(w, status)
+		w.Write([]byte(status))
 	} else {
 		http.Error(w, "Missing url argument", 300)
 		return

--- a/handlers/handler_test.go
+++ b/handlers/handler_test.go
@@ -1,0 +1,96 @@
+package handlers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	batchtypev1 "k8s.io/client-go/kubernetes/typed/batch/v1"
+)
+
+type mockSQSClient struct {
+	sqsiface.SQSAPI
+	mock.Mock
+}
+
+func (m *mockSQSClient) SendMessage(opts *sqs.SendMessageInput) (*sqs.SendMessageOutput, error) {
+	args := m.Called(opts)
+	return args.Get(0).(*sqs.SendMessageOutput), args.Error(1)
+}
+
+type mockJobClient struct {
+	batchtypev1.JobInterface
+	mock.Mock
+}
+
+func (m *mockJobClient) List(opts metav1.ListOptions) (*batchv1.JobList, error) {
+	args := m.Called(opts)
+	return args.Get(0).(*batchv1.JobList), args.Error(1)
+}
+
+func TestCheckJobs(t *testing.T) {
+	sqsClient := &mockSQSClient{}
+	sqsClient.On("SendMessage", mock.Anything).Return(&sqs.SendMessageOutput{
+		MessageId: aws.String("new message id"),
+	}, nil)
+	jobClient := &mockJobClient{}
+	jobClient.On("List", mock.Anything).Return(&batchv1.JobList{
+		Items: []batchv1.Job{
+			{
+				Status: batchv1.JobStatus{
+					Failed: 1,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID("job1"),
+				},
+			},
+		},
+	}, nil)
+
+	messageBytes, _ := json.Marshal(map[string]string{
+		"Message": string("test message"),
+	})
+	message := string(messageBytes)
+
+	handler := &SQSHandler{
+		MonitoredJobs: []*JobInfo{
+			{
+				UID:     "job1",
+				Retries: MAX_RETRIES - 1,
+				SQSMessage: &sqs.Message{
+					MessageId: aws.String("existing message id"),
+					Body:      aws.String(message),
+				},
+			},
+		},
+		sqsClient: sqsClient,
+		jobHandler: &jobHandler{
+			jobClient: jobClient,
+		},
+	}
+	handler.checkJobs()
+
+	// This is not a good thing. We are going to send a new message with a new job
+	// id and so we end up duplicating one message to many over
+	sqsClient.AssertCalled(t, "SendMessage", &sqs.SendMessageInput{
+		MessageBody: aws.String(message),
+		QueueUrl:    aws.String(""),
+	})
+	assert.Equal(t, handler.MonitoredJobs, []*JobInfo{
+		{
+			UID:     "job1",
+			Retries: MAX_RETRIES,
+			SQSMessage: &sqs.Message{
+				MessageId: aws.String("existing message id"),
+				Body:      aws.String(message),
+			},
+		},
+	})
+}

--- a/handlers/handler_test.go
+++ b/handlers/handler_test.go
@@ -4,70 +4,30 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/sqs"
-	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
-	"github.com/stretchr/testify/mock"
-	batchv1 "k8s.io/api/batch/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	batchtypev1 "k8s.io/client-go/kubernetes/typed/batch/v1"
+	"github.com/stretchr/testify/assert"
 )
 
-type mockSQSClient struct {
-	sqsiface.SQSAPI
-	mock.Mock
-}
-
-func (m *mockSQSClient) SendMessage(opts *sqs.SendMessageInput) (*sqs.SendMessageOutput, error) {
-	args := m.Called(opts)
-	return args.Get(0).(*sqs.SendMessageOutput), args.Error(1)
-}
-
-type mockJobClient struct {
-	batchtypev1.JobInterface
-	mock.Mock
-}
-
-func (m *mockJobClient) List(opts metav1.ListOptions) (*batchv1.JobList, error) {
-	args := m.Called(opts)
-	return args.Get(0).(*batchv1.JobList), args.Error(1)
-}
-
-func TestCheckJobs(t *testing.T) {
-	sqsClient := &mockSQSClient{}
-	sqsClient.On("SendMessage", mock.Anything).Return(&sqs.SendMessageOutput{
-		MessageId: aws.String("new message id"),
-	}, nil)
-	jobClient := &mockJobClient{}
-	jobClient.On("List", mock.Anything).Return(&batchv1.JobList{
-		Items: []batchv1.Job{
+func TestGetObjectsFromSQSMessage(t *testing.T) {
+	recordsBytes, _ := json.Marshal(map[string]interface{}{
+		"Records": []map[string]interface{}{
 			{
-				Status: batchv1.JobStatus{
-					Failed: 1,
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					UID: types.UID("job1"),
+				"s3": map[string]interface{}{
+					"bucket": map[string]interface{}{
+						"name": "mybucket",
+					},
+					"object": map[string]interface{}{
+						"key": "mykey",
+					},
 				},
 			},
 		},
-	}, nil)
-
+	})
 	messageBytes, _ := json.Marshal(map[string]string{
-		"Message": string("test message"),
+		"Message": string(recordsBytes),
 	})
 	message := string(messageBytes)
 
-	handler := &SQSHandler{
-		sqsClient: sqsClient,
-		jobHandler: &jobHandler{
-			jobClient: jobClient,
-		},
-	}
-	handler.checkJobs()
+	objects := getObjectsFromSQSMessage(message)
 
-	sqsClient.AssertCalled(t, "SendMessage", &sqs.SendMessageInput{
-		MessageBody: aws.String(message),
-		QueueUrl:    aws.String(""),
-	})
+	assert.Equal(t, objects, []string{"s3://mybucket/mykey"})
 }

--- a/handlers/jobs_api.go
+++ b/handlers/jobs_api.go
@@ -19,7 +19,8 @@ func status(w http.ResponseWriter, r *http.Request) {
 	}
 	UID := r.URL.Query().Get("UID")
 	if UID != "" {
-		result, errUID := GetJobStatusByID(UID)
+		jobHandler := NewJobHandler()
+		result, errUID := jobHandler.GetJobStatusByID(UID)
 		if errUID != nil {
 			http.Error(w, errUID.Error(), 500)
 			return
@@ -44,7 +45,9 @@ func list(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Not supported request method.", 405)
 		return
 	}
-	result := listJobs(getJobClient())
+
+	jobHandler := NewJobHandler()
+	result := jobHandler.listJobs()
 
 	out, err := json.Marshal(result)
 	if err != nil {

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -47,8 +47,6 @@ func GetValueFromJSON(jsonBytes []byte, keys []string) (interface{}, error) {
 		return nil, errors.New("can not unmarshal data bytes")
 	}
 	for _, key := range keys {
-		fmt.Println("dataMap", dataMap)
-		fmt.Println("key", key)
 		if containKey(dataMap.(map[string]interface{}), key) {
 			dataMap = dataMap.(map[string]interface{})[key]
 		} else {

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -44,13 +44,15 @@ func GetValueFromJSON(jsonBytes []byte, keys []string) (interface{}, error) {
 		return nil, err
 	}
 	if dataMap == nil {
-		return nil, fmt.Errorf("Can not unmarshal data bytes")
+		return nil, errors.New("can not unmarshal data bytes")
 	}
 	for _, key := range keys {
+		fmt.Println("dataMap", dataMap)
+		fmt.Println("key", key)
 		if containKey(dataMap.(map[string]interface{}), key) {
 			dataMap = dataMap.(map[string]interface{})[key]
 		} else {
-			return nil, errors.New(string(jsonBytes) + " does not contain key " + key)
+			return nil, fmt.Errorf("%s does not contain key %s", string(jsonBytes), key)
 		}
 	}
 	return dataMap, nil


### PR DESCRIPTION
Jira Ticket: [DEVOPS-22](https://ctds-planx.atlassian.net/browse/DEVOPS-22)

I may misunderstand some of the ssjdispatcher architecture, but I believe I have found several bugs that relate to DEVOPS-22

See here an example where a single SQS message that failed to index properly was multiplied to thousands. Over time this increasing rate of data duplication is exponential.

```
$ aws sqs get-queue-attributes --queue-url "https://sqs.us-east-1.amazonaws.com/redacted" --attribute-names ApproximateNumberOfMessages
{
    "Attributes": {
        "ApproximateNumberOfMessages": "14327"
    }
}
...(a second later)...
$ aws sqs get-queue-attributes --queue-url "https://sqs.us-east-1.amazonaws.com/redacted" --attribute-names ApproximateNumberOfMessages
{
    "Attributes": {
        "ApproximateNumberOfMessages": "14390"
    }
}
...(a second later)...
$ aws sqs get-queue-attributes --queue-url "https://sqs.us-east-1.amazonaws.com/redacted" --attribute-names ApproximateNumberOfMessages
{
    "Attributes": {
        "ApproximateNumberOfMessages": "14429"
    }
}
```

**Steps to reproduce**

1. An SQS message is received and immediately removed from the queue
2. A k8s job is created and a new UID is generated
3. If the job fails (not by exceeding the max retries yet), we put the message back on the queue (pretend it failed)
4. The job gets re-processed again.
  4.1 HOWEVER, when it gets re-processed, a *new* k8s job with a *new* UID is created. **This is a problem**
  4.2 The in-memory tracking system used to monitor jobs is now inaccurate
  4.3 The in-memory tracking sees two k8s jobs and tracks retries for them both
5. Repeat the above for exponential growth

**Cause(s)**

We reap jobs every 120 seconds (or as set by env), we check for jobs and re-send them on SQS every 30 seconds, we poll for messages with a timeout of 20 seconds and a wait of 1 second. Due to this timing we could end up in a position (based on the steps above) where a single message is received, and in 30 seconds we put it back on the queue with a _new_ unique id. Meanwhile the app is still "tracking" the old job. If it fails we will again re-send the message in 30 seconds. If it succeeds we have now indexed data multiple times.

This timing explains behavior I've seen where messages do get purged and the number of messages in the queue can go down from time to time, but overall the trend is to continually increase.

**Proposal**

The in-memory store is problematic specifically because it cannot track jobs if ssjdispatcher crashes and (assuming we ever ran multiple instances and re-inserted messages on the queue) it could erroneously track a message that was re-sent and tracked by a different ssjdispatcher instance. **The in-memory store introduces room for drift and inconsistency from the actual state of running jobs.**

My proposal is that we don't trust an in-memory store, and rather use the `List()` API to canonically inform us about the state of jobs. This makes sure jobs aren't lost and forever orphaned or that we accidentally de-duplicate data. Rather than re-send messages we trust that the batch job operation is a stable layer that monitors and can inform us about job state.

These new changes do not resolve primary/secondary/cluster configurations for ssjdispatcher, but should at least be more stable for that future state.

### Bug Fixes

* Don't re-send failing messages to SQS which will result in duplicate data
* Properly purge messages after they exceed the retry count

### Improvements

* Move away from in-memory job tracking

### Dependency updates

* Update to go 1.16
