### PR TITLE
Fix an endless loop in ssjdispatcher when it is using an SQS queue

### DIFF
--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -254,6 +254,7 @@ func (handler *SQSHandler) HandleSQSMessage(message *sqs.Message) error {
 		for runningJobs > maxJobs {
 			glog.Infof("[HandleSQSMessage] running jobs greater than max jobs (%d/%d)", runningJobs, maxJobs)
 			time.Sleep(5 * time.Second)
+			runningJobs = handler.jobHandler.GetNumberRunningJobs()
 		}
 		jobInfo, err := CreateK8sJob(objectPath, jobConfig)
 		if err != nil {


### PR DESCRIPTION
- Describe what this pull request does.
This change fixes an endless loop in ssjdispatcher when run off an SQS queue with fence. 

- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
Needs integration with AWS SQS. Therefore needs to be tested in situ. Without this patch ssjdispatcher will stop processing files after maxJobs files have been processed irrespective whether the job finished or not. 

- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
Simple bugfix

-->

### Bug Fixes
Fixes an endless loop in ssjdispatcher
